### PR TITLE
removed unnecessary import causing import error

### DIFF
--- a/push_notifications/migrations/0001_initial.py
+++ b/push_notifications/migrations/0001_initial.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 from django.db import models, migrations
 import push_notifications.fields
 from django.conf import settings
-import uuidfield.fields
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Running migrations on Django 1.8 will cause ImportError as uuidfield will not be installed.